### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
PR

## Description

Via @tynes:
>Since there are so many untrusted dependencies used in the typescript code, vulnerabilities can be found at any time and we need to be able to quickly update the impacted dependencies when this happens.

Dependabot is now native to Github 👏 
This means all we need to do is add a new `dependabot.yml` file under the `.github` directory. Within the config we can specify the config where the dependencies are managed. For example the location of package.json for nodejs. Additionally/conveniently if using Yarn workspaces Dependabot should automatically handle package.json files in subdirectories of the workspace (as noted here https://github.com/dependabot/dependabot-core/issues/603)!


## Questions
- Is daily an appropriate interval? From examples this seems pretty typical

## Metadata
### Fixes
- Fixes https://github.com/ethereum-optimism/roadmap/issues/51

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
