### PR TITLE
Bumping contract version in dependencies to 0.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,23 @@
     "lint:fix": "yarn run lint:fix:typescript",
     "lint:fix:typescript": "prettier --config prettier-config.json --write \"{src,test}/**/*.ts\""
   },
+  "dependencies": {
+    "@eth-optimism/contracts": "^0.1.10",
+    "@eth-optimism/ethereumjs-vm": "^4.2.0-alpha.2",
+    "@nomiclabs/hardhat-truffle5": "^2.0.0",
+    "bn.js": "^5.1.3",
+    "ethereumjs-account": "^3.0.0",
+    "ethers": "^5.0.31",
+    "ethjs-common-v1": "npm:ethereumjs-common@1.5.0",
+    "ethjs-util-v6": "npm:ethereumjs-util@6.2.1",
+    "node-fetch": "^2.6.1"
+  },
+  "peerDependencies": {
+    "@nomiclabs/hardhat-ethers": "^2.0.1",
+    "ethereum-waffle": "^3.0.0",
+    "ethers": "^5.0.0",
+    "hardhat": "^2.0.0"
+  },
   "devDependencies": {
     "@eth-optimism/dev": "^1.1.1",
     "@nomiclabs/hardhat-ethers": "^2.0.1",
@@ -41,22 +58,5 @@
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
     "typescript": "~4.0.3"
-  },
-  "dependencies": {
-    "@eth-optimism/contracts": "^0.1.9",
-    "@eth-optimism/ethereumjs-vm": "^4.2.0-alpha.2",
-    "@nomiclabs/hardhat-truffle5": "^2.0.0",
-    "bn.js": "^5.1.3",
-    "ethereumjs-account": "^3.0.0",
-    "ethers": "^5.0.31",
-    "ethjs-common-v1": "npm:ethereumjs-common@1.5.0",
-    "ethjs-util-v6": "npm:ethereumjs-util@6.2.1",
-    "node-fetch": "^2.6.1"
-  },
-  "peerDependencies": {
-    "@nomiclabs/hardhat-ethers": "^2.0.1",
-    "ethereum-waffle": "^3.0.0",
-    "ethers": "^5.0.0",
-    "hardhat": "^2.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
   resolved "https://registry.yarnpkg.com/@ensdomains/resolver/-/resolver-0.2.4.tgz#c10fe28bf5efbf49bff4666d909aed0265efbc89"
   integrity sha512-bvaTH34PMCbv6anRa9I/0zjLJgY4EuznbEMgbV77JBCQ9KNC46rzi0avuxpOfu+xDjPEtSFGqVEOr5GlUSGudA==
 
-"@eth-optimism/contracts@^0.1.9":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/contracts/-/contracts-0.1.9.tgz#01a8b7816b2fcc8408c102d81e455868e4a09bc3"
-  integrity sha512-vLW6vnFymdSWveF7qMUwYNFGSOYI90qosOJLxalOLi2dvJ6Glh7wtnCF6GvXMb3bNQ1fS5eFwHzjhWIbBMvWRA==
+"@eth-optimism/contracts@^0.1.10":
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/contracts/-/contracts-0.1.10.tgz#4f03d9d4a6ed4ff6c277b439adb109e09bb2a7a5"
+  integrity sha512-6d26oCnywfqo181vetS6oEzvZyxhvSVRfkWx7sA1gySuxfZMIhwsvUWIebOsPpT/VQwmx2BwkPeu60ms4pgoXg==
   dependencies:
     "@ethersproject/abstract-provider" "^5.0.8"
     "@ethersproject/contracts" "^5.0.5"


### PR DESCRIPTION
Also moved the dependencies around so that the order is `dependencies`, `peerDependencies`, `devDependencies`.