### PR TITLE
Fixed a bug where the compiler would throw for abstract contracts

### DIFF
--- a/src/hardhat/compiler/index.ts
+++ b/src/hardhat/compiler/index.ts
@@ -124,7 +124,7 @@ subtask(
     // Just doing this to add some extra useful information to any errors in the OVM compiler output.
     ovmOutput.errors = (ovmOutput.errors || []).map((error: any) => {
       if (error.severity === 'error') {
-        error.formattedMessage = `OVM Compiler Error (silence by adding: "// @unsupported: ovm" to the top of this file):\n ${error.formattedMessage}`
+        error.formattedMessage = `OVM Compiler Error (insert "// @unsupported: ovm" if you don't want this file to be compiled for the OVM):\n ${error.formattedMessage}`
       }
 
       return error
@@ -151,7 +151,7 @@ subtask(
 
           // Need to fix any link references in the OVM outputs. Otherwise we'll be trying to link
           // an OVM-compiled contract to EVM-compiled contracts.
-          const linkRefs = contractOutput.evm.bytecode.linkReferences
+          const linkRefs = contractOutput.evm?.bytecode?.linkReferences
           for (const linkRefFileName of Object.keys(linkRefs || {})) {
             for (const [linkRefName, linkRefOutput] of Object.entries(
               linkRefs[linkRefFileName]

--- a/src/hardhat/internal/provider.ts
+++ b/src/hardhat/internal/provider.ts
@@ -38,7 +38,7 @@ export const makeL2Provider = (hre: HardhatRuntimeEnvironment) => {
     hre.artifacts
   )
 
-  let provider = findProvider(actualprovider)
+  const provider = findProvider(actualprovider)
 
   // const l1ProviderActual = hre.network.provider
   // let l1Provider = l1ProviderActual

--- a/tslint.json
+++ b/tslint.json
@@ -1,3 +1,8 @@
 {
-    "extends": "@eth-optimism/dev/tslint.json"
+    "extends": "@eth-optimism/dev/tslint.json",
+    "rules": {
+        "prefer-conditional-expression": false,
+        "array-type": false,
+        "no-var-requires": false
+    }
 }


### PR DESCRIPTION
Title says it all, mostly. Bug had to do with `.bytecode` being undefined in the following line:

https://github.com/ethereum-optimism/plugins/blob/f2cacfd4a41cc925fdb14f2141d59088b289ce67/src/hardhat/compiler/index.ts#L154

This happens for abstract contracts. Whoops! Added some `?` keywords which automatically handle the undefined case.

Also did some linting fixes.