### PR TITLE
Create a warning for outdated plugins

### DIFF
--- a/src/ganache/index.ts
+++ b/src/ganache/index.ts
@@ -161,3 +161,12 @@ export const ganache = {
   provider,
   server,
 }
+
+// We're iceboxing this plugin for a bit.
+console.log(`
+@eth-optimism/plugins/ganache: WARNING -- this plugin has been moved to
+our develoment backlog and is not currently being actively maintained. Most
+contracts should "just work" on the OVM. If you want to explicitly test on the
+OVM you should run an L2 geth node. See the below link for more information:
+https://community.optimism.io/docs/developers/integration.html
+`)

--- a/src/hardhat/compiler/index.ts
+++ b/src/hardhat/compiler/index.ts
@@ -77,14 +77,7 @@ subtask(
     { config, run },
     runSuper
   ) => {
-    // Just some silly sanity checks, make sure we have a solc version to download. Our format is
-    // `X.Y.Z` (for now).
-    let ovmSolcVersion: string
-    if (!config.ovm || !config.ovm.solcVersion) {
-      ovmSolcVersion = DEFAULT_OVM_SOLC_VERSION
-    } else {
-      ovmSolcVersion = config.ovm.solcVersion
-    }
+    const ovmSolcVersion = config.ovm?.solcVersion || DEFAULT_OVM_SOLC_VERSION
 
     // Get a path to a soljson file.
     const ovmSolcPath = await getOvmSolcPath(ovmSolcVersion)
@@ -105,7 +98,7 @@ subtask(
     }
 
     // Separate the EVM and OVM inputs.
-    for (const file of Object.keys(input.sources)) {
+    for (const file of Object.keys(input.sources || {})) {
       evmInput.sources[file] = input.sources[file]
 
       // Ignore any contract that has this tag.
@@ -114,7 +107,9 @@ subtask(
       }
     }
 
-    // Build both inputs separately.
+    // Build both inputs separately. We build the EVM output using `runSuper` because we don't know
+    // if the user is using a `solcjs` wrapper or a native `solc` binary. OVM output is always
+    // built with `solcjs`.
     const evmOutput = await runSuper({ input: evmInput, solcPath })
     const ovmOutput = await run(TASK_COMPILE_SOLIDITY_RUN_SOLCJS, {
       input: ovmInput,

--- a/src/hardhat/ethers/index.ts
+++ b/src/hardhat/ethers/index.ts
@@ -155,3 +155,12 @@ extendEnvironment((hre) => {
     }
   })
 })
+
+// We're iceboxing this plugin for a bit.
+console.log(`
+@eth-optimism/plugins/hardhat/ethers: WARNING -- this plugin has been moved to
+our develoment backlog and is not currently being actively maintained. Most
+contracts should "just work" on the OVM. If you want to explicitly test on the
+OVM you should run an L2 geth node. See the below link for more information:
+https://community.optimism.io/docs/developers/integration.html
+`)

--- a/src/hardhat/web3/index.ts
+++ b/src/hardhat/web3/index.ts
@@ -40,3 +40,12 @@ task(TASK_TEST_SETUP_TEST_ENVIRONMENT, async (args, hre: any, runSuper) => {
   // Finish off by running the parent function.
   return runSuper(args)
 })
+
+// We're iceboxing this plugin for a bit.
+console.log(`
+@eth-optimism/plugins/hardhat/web3: WARNING -- this plugin has been moved to
+our develoment backlog and is not currently being actively maintained. Most
+contracts should "just work" on the OVM. If you want to explicitly test on the
+OVM you should run an L2 geth node. See the below link for more information:
+https://community.optimism.io/docs/developers/integration.html
+`)

--- a/src/waffle/index.ts
+++ b/src/waffle/index.ts
@@ -37,3 +37,12 @@ export class MockProvider extends providers.Web3Provider {
 export const waffle = {
   MockProvider,
 }
+
+// We're iceboxing this plugin for a bit.
+console.log(`
+@eth-optimism/plugins/waffle: WARNING -- this plugin has been moved to
+our develoment backlog and is not currently being actively maintained. Most
+contracts should "just work" on the OVM. If you want to explicitly test on the
+OVM you should run an L2 geth node. See the below link for more information:
+https://community.optimism.io/docs/developers/integration.html
+`)


### PR DESCRIPTION
We're planning to icebox a few plugins. The JSvm is extremely nice, but it's too difficult to maintain two different node forks right now. Most contracts shouldn't even need the custom JSvm. We'll reintroduce these plugins eventually (or if community members want to maintain them). Users will be recommended to use our `up.sh` script.