### PR TITLE
fix: Modify cache path alongside artifacts path

### DIFF
--- a/src/hardhat/compiler/index.ts
+++ b/src/hardhat/compiler/index.ts
@@ -135,8 +135,14 @@ extendEnvironment((hre) => {
       artifactsPath = artifactsPath + '-ovm'
     }
 
+    let cachePath = hre.config.paths.cache
+    if (!cachePath.endsWith('-ovm')) {
+      cachePath = cachePath + '-ovm'
+    }
+
     // Forcibly update the artifacts object.
     hre.config.paths.artifacts = artifactsPath
+    hre.config.paths.cache = cachePath
     ;(hre as any).artifacts = new Artifacts(artifactsPath)
     ;(hre.network as any).ovm = true
   }


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes a bug where the ovm/evm caches would conflict.

**Additional context**
Will require that we release a new version.
