### PR TITLE
use network.config.ovm

### DIFF
--- a/src/hardhat/compiler/index.ts
+++ b/src/hardhat/compiler/index.ts
@@ -75,7 +75,7 @@ const getOvmSolcPath = async (version: string): Promise<string> => {
 subtask(
   TASK_COMPILE_SOLIDITY_RUN_SOLC,
   async (args: { input: any; solcPath: string }, hre, runSuper) => {
-    if ((hre.network as any).ovm !== true) {
+    if (hre.network.ovm !== true) {
       return runSuper(args)
     }
 
@@ -127,9 +127,10 @@ subtask(
 )
 
 extendEnvironment((hre) => {
-  if (process.env.TARGET === 'ovm') {
-    ;(hre.network as any).ovm = true
-    // Quick check to make sure we don't accidentally perform this transform multiple times.
+
+  if (hre.network.config.ovm ) { // || process.env.TARGET // we could make it activate by env variable too but I would make it a less generic one than TARGET, more like OPTIMISM_TARGET
+    hre.network.ovm = hre.network.config.ovm;
+
     let artifactsPath = hre.config.paths.artifacts
     if (!artifactsPath.endsWith('-ovm')) {
       artifactsPath = artifactsPath + '-ovm'
@@ -141,9 +142,8 @@ extendEnvironment((hre) => {
     }
 
     // Forcibly update the artifacts object.
-    hre.config.paths.artifacts = artifactsPath
-    hre.config.paths.cache = cachePath
-    ;(hre as any).artifacts = new Artifacts(artifactsPath)
-    ;(hre.network as any).ovm = true
+    hre.config.paths.artifacts = artifactsPath;
+    hre.config.paths.cache = cachePath;
+    (hre as any).artifacts = new Artifacts(artifactsPath);
   }
 })

--- a/src/hardhat/compiler/type-extensions.ts
+++ b/src/hardhat/compiler/type-extensions.ts
@@ -12,4 +12,28 @@ declare module 'hardhat/types/config' {
       solcVersion?: string
     }
   }
+
+  interface HardhatNetworkUserConfig {
+    ovm?: boolean;
+  }
+
+  interface HttpNetworkUserConfig {
+    ovm?: boolean;
+  }
+
+
+  interface HardhatNetworkConfig {
+    ovm: boolean;
+  }
+
+  interface HttpNetworkConfig {
+    ovm: boolean;
+  }
+}
+
+
+declare module 'hardhat/types/runtime' {
+  interface Network {
+    ovm: boolean;
+  }
 }


### PR DESCRIPTION
**Description**
This PR add an `ovm` field to the network config, removing the need for manipulating env variable and making it easier for user.
They just need to specify that a particular network is ovm and then every compilation for that network will use the ovm artifact

**Additional context**
I modified the tutorial to reflect the usage of that modified plugin :  https://github.com/ethereum-optimism/optimism-tutorial/pull/18