### PR TITLE
add ignore file list on compilation

### DIFF
--- a/src/hardhat/compiler/index.ts
+++ b/src/hardhat/compiler/index.ts
@@ -87,6 +87,7 @@ subtask(
           else {
               //console.log(file + ' included');
           }
+        }
         return runSuper(args)
     }
 

--- a/src/hardhat/compiler/index.ts
+++ b/src/hardhat/compiler/index.ts
@@ -75,8 +75,19 @@ const getOvmSolcPath = async (version: string): Promise<string> => {
 subtask(
   TASK_COMPILE_SOLIDITY_RUN_SOLC,
   async (args: { input: any; solcPath: string }, hre, runSuper) => {
+    const ignoreRxList = hre.network.config.ignoreRxList || [];
+    const ignore = (filename: string) => ignoreRxList.reduce((ignored: boolean, rx: string | RegExp) => ignored || new RegExp(rx).test(filename), false);
     if (hre.network.ovm !== true) {
-      return runSuper(args)
+        // Separate the EVM and OVM inputs.
+        for (const file of Object.keys(args.input.sources)) {
+          // Ignore any contract that has this tag or in ignore list
+          if (args.input.sources[file].content.includes('// @unsupported: evm') || ignore(file)) {
+              delete args.input.sources[file];
+          }
+          else {
+              //console.log(file + ' included');
+          }
+        return runSuper(args)
     }
 
     // Just some silly sanity checks, make sure we have a solc version to download. Our format is
@@ -101,8 +112,8 @@ subtask(
 
     // Separate the EVM and OVM inputs.
     for (const file of Object.keys(args.input.sources)) {
-      // Ignore any contract that has this tag.
-      if (!args.input.sources[file].content.includes('// @unsupported: ovm')) {
+      // Ignore any contract that has this tag or in ignore list
+      if (!args.input.sources[file].content.includes('// @unsupported: ovm') && !ignore(file)) {
         ovmInput.sources[file] = args.input.sources[file]
       }
     }

--- a/src/hardhat/compiler/type-extensions.ts
+++ b/src/hardhat/compiler/type-extensions.ts
@@ -15,19 +15,23 @@ declare module 'hardhat/types/config' {
 
   interface HardhatNetworkUserConfig {
     ovm?: boolean;
+    ignoreRxList?: string[];
   }
 
   interface HttpNetworkUserConfig {
     ovm?: boolean;
+    ignoreRxList?: string[];
   }
 
 
   interface HardhatNetworkConfig {
     ovm: boolean;
+    ignoreRxList: string[];
   }
 
   interface HttpNetworkConfig {
     ovm: boolean;
+    ignoreRxList: string[];
   }
 }
 
@@ -35,5 +39,6 @@ declare module 'hardhat/types/config' {
 declare module 'hardhat/types/runtime' {
   interface Network {
     ovm: boolean;
+    ignoreRxList: string[];
   }
 }


### PR DESCRIPTION
**Description**
just an an optional 'ignore/skip' list(of regex) when doing compilation as libraries like @openzeppelin may not play nice with ovm compiler yet would be included by hardhat

use like this in the hardhat.config.js

 networks: {
    localhost_l1: {
      url: networks.localhost.l1RpcUrl,
      accounts,
      ignoreRxList: ["ovmzeppelin/.*"]
    },
    localhost_l2: {
      url: networks.localhost.l2RpcUrl,
      accounts,
      ovm:true,
      ignoreRxList: ["@openzeppelin.*"]
    },